### PR TITLE
CI/CD сборка и пуш dockerimage в hub.docker.com

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -23,7 +23,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: alexstep/localizer-backend:latest
+          tags: ${{github.repository}}:latest
       -
         name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,29 @@
+name: ci
+
+on:
+  push:
+    branches: master
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: alexstep/localizer-backend:latest
+      -
+        name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,6 @@ RUN npm prune --production
 # Чистка node_modules от "хлама" файлов README LICENSE etc
 RUN npx modclean --no-progress --run
 
-# Удаляем явно не нужные в проде каталоги и файлы (если их пропустил dockerignore)
-RUN rm -rf .git .github docs tests .npmrc .nvmrc .editorconfig .eslintrc .foreverignore .gitignore .dockerignore Dockerfile
-
 
 # 
 # Запуск в продакшн
@@ -25,9 +22,9 @@ FROM node:14-alpine3.10
 WORKDIR /app
 
 # Копируем из билдера "чистое" приложение
-COPY --from=builder /sources/ .
-# в данном случае к базовому образу node:14-alpine3.10 добавляется только один слой файловой системы - COPY
-# слои со всеми install, rm остаются в предыдущем, неиспользуемом образе(builder)
+COPY --from=builder /sources/dist ./dist
+COPY --from=builder /sources/package*.json .
+COPY --from=builder /sources/node_modules ./node_modules
 
 EXPOSE 1337
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,8 @@ WORKDIR /app
 
 # Копируем из билдера "чистое" приложение
 COPY --from=builder /sources/dist ./dist
-COPY --from=builder /sources/package*.json .
+COPY --from=builder /sources/package.json .
+COPY --from=builder /sources/package-lock.json .
 COPY --from=builder /sources/node_modules ./node_modules
 
 EXPOSE 1337


### PR DESCRIPTION
Для работы CI требуется указать в настройках репозитория логин и токен пользователя hub.docker.com

DOCKERHUB_USERNAME - логин на сайте docker, в вашем случае желательно чтобы он был backmeupplz
DOCKERHUB_TOKEN  - создается тут https://hub.docker.com/settings/security

Поле публикации образов в registry можно будет давать юзерам примерно такой файл https://gist.github.com/alexstep/ef3abba35f2bc37826b7f8d0bd4a9497 только пути(`image`) в нем переписать на свои.

Или какую-то такую команду установки:
```bash
curl -L 'https://git.io/JtJK0' > docker-compose.yml && docker-compose up -d
```

Для сокращения ссылки на gist можно воспользоваться https://git.io/